### PR TITLE
Remove dependency on firtool and llvm-link [DisableCI]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,18 +14,8 @@ endef
 help:
 	@$(HELP_TEXT)
 
-JHLS ?= jhls
+JHLS = jhls
 HLS_TEST_ROOT ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-FIRTOOL ?= firtool
-
-# LLVM related variables
-LLVMCONFIG=llvm-config-17
-CLANG_BIN=$(shell $(LLVMCONFIG) --bindir)
-CLANG=$(CLANG_BIN)/clang
-LLC=$(CLANG_BIN)/llc
-LLVM_LINK=$(CLANG_BIN)/llvm-link
-
-LD_LIBRARY_PATH = $(shell $(LLVMCONFIG) --libdir)
 
 include Makefile.sub
 

--- a/Makefile.sub
+++ b/Makefile.sub
@@ -44,10 +44,8 @@ $(HLS_TEST_BUILD)/%.hls: $(HLS_TEST_SRC)/%.c
 	@mkdir -p $(@D)
 	@set -e && printf '$(BLUE)Building: $(NC)%s\n' $*
 	@$(JHLS) $^ $(HLS_TEST_ADDITIONAL_SRC) $(HLS_TEST_ADDITIONAL_FLAGS) --circt --hls-function=kernel -o $@ > /dev/null
-	@$(LLVM_LINK) $@.re*.ll | $(LLC) -O3 --relocation-model=pic -filetype=obj -o $@.o
 	@+TMPDIR=`mktemp -d`; \
-	$(FIRTOOL) -format=fir --verilog $@.fir > $$TMPDIR/jlm_hls.v; \
-	VERILATOR_ROOT=/usr/share/verilator verilator_bin $(VERILATOR_TRACE) --cc --build --exe -Wno-WIDTH -Mdir $$TMPDIR -MAKEFLAGS CXX=g++ -CFLAGS -g --assert -CFLAGS " -fPIC" -o $@ $$TMPDIR/jlm_hls.v $@.o $@.harness.cpp > /dev/null
+	VERILATOR_ROOT=/usr/share/verilator verilator_bin $(VERILATOR_TRACE) --cc --build --exe -Wno-WIDTH -Mdir $$TMPDIR -MAKEFLAGS CXX=g++ -CFLAGS -g --assert -CFLAGS " -fPIC" -o $@ $@.v $@.o $@.harness.cpp > /dev/null
 
 # This target is used for running and checking built tests
 .PHONY: hls-test-run/%.hls


### PR DESCRIPTION
The benefit is that running the benchmark suite will only depend on jlm binaries and verilator, i.e., the suite becomes agnostic to the LLVM version and CIRCT and no need for paths to various tools like firtool and the right version of llc and llvm-link.

The CI is disabled, as jhls has to be updated to use llvm-link and compile the resulting llvm-IR file into an object file.
