### PR TITLE
Removes dependency on firtool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ help:
 
 JHLS ?= jhls
 HLS_TEST_ROOT ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-FIRTOOL ?= firtool
 
 # LLVM related variables
 LLVMCONFIG=llvm-config-17

--- a/Makefile.sub
+++ b/Makefile.sub
@@ -46,7 +46,7 @@ $(HLS_TEST_BUILD)/%.hls: $(HLS_TEST_SRC)/%.c
 	@$(JHLS) $^ $(HLS_TEST_ADDITIONAL_SRC) $(HLS_TEST_ADDITIONAL_FLAGS) --circt --hls-function=kernel -o $@ > /dev/null
 	@$(LLVM_LINK) $@.re*.ll | $(LLC) -O3 --relocation-model=pic -filetype=obj -o $@.o
 	@+TMPDIR=`mktemp -d`; \
-	$(FIRTOOL) -format=fir --verilog $@.fir > $$TMPDIR/jlm_hls.v; \
+	cp $@.v $$TMPDIR/jlm_hls.v; \
 	VERILATOR_ROOT=/usr/share/verilator verilator_bin $(VERILATOR_TRACE) --cc --build --exe -Wno-WIDTH -Mdir $$TMPDIR -MAKEFLAGS CXX=g++ -CFLAGS -g --assert -CFLAGS " -fPIC" -o $@ $$TMPDIR/jlm_hls.v $@.o $@.harness.cpp > /dev/null
 
 # This target is used for running and checking built tests


### PR DESCRIPTION
jlm-hls directly generates Verilog, so no longer necessary to rely on firtool.

Currently, a copy of the generated Verilog is needed, as Verilator expects the Verilog file to have a specific name. This will be fixed in a later PR.