### PR TITLE
Removed dependency on llvm-link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,17 +14,8 @@ endef
 help:
 	@$(HELP_TEXT)
 
-JHLS ?= jhls
+JHLS = jhls
 HLS_TEST_ROOT ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-
-# LLVM related variables
-LLVMCONFIG=llvm-config-17
-CLANG_BIN=$(shell $(LLVMCONFIG) --bindir)
-CLANG=$(CLANG_BIN)/clang
-LLC=$(CLANG_BIN)/llc
-LLVM_LINK=$(CLANG_BIN)/llvm-link
-
-LD_LIBRARY_PATH = $(shell $(LLVMCONFIG) --libdir)
 
 include Makefile.sub
 

--- a/Makefile.sub
+++ b/Makefile.sub
@@ -44,7 +44,6 @@ $(HLS_TEST_BUILD)/%.hls: $(HLS_TEST_SRC)/%.c
 	@mkdir -p $(@D)
 	@set -e && printf '$(BLUE)Building: $(NC)%s\n' $*
 	@$(JHLS) $^ $(HLS_TEST_ADDITIONAL_SRC) $(HLS_TEST_ADDITIONAL_FLAGS) --circt --hls-function=kernel -o $@ > /dev/null
-	@$(LLVM_LINK) $@.re*.ll | $(LLC) -O3 --relocation-model=pic -filetype=obj -o $@.o
 	@+TMPDIR=`mktemp -d`; \
 	cp $@.v $$TMPDIR/jlm_hls.v; \
 	VERILATOR_ROOT=/usr/share/verilator verilator_bin $(VERILATOR_TRACE) --cc --build --exe -Wno-WIDTH -Mdir $$TMPDIR -MAKEFLAGS CXX=g++ -CFLAGS -g --assert -CFLAGS " -fPIC" -o $@ $$TMPDIR/jlm_hls.v $@.o $@.harness.cpp > /dev/null


### PR DESCRIPTION
jhls performs the linking of llvm-IR and compiles it to and object file, so the depenency on llvm tools are removed.