### PR TITLE
Add cleanup of the tmp directories used by verilator

### DIFF
--- a/Makefile.sub
+++ b/Makefile.sub
@@ -44,7 +44,11 @@ $(HLS_TEST_BUILD)/%.hls: $(HLS_TEST_SRC)/%.c
 	@mkdir -p $(@D)
 	@set -e && printf '$(BLUE)Building: $(NC)%s\n' $*
 	@$(JHLS) $^ $(HLS_TEST_ADDITIONAL_SRC) $(HLS_TEST_ADDITIONAL_FLAGS) --circt --hls-function=kernel -o $@ > /dev/null
-	@+VERILATOR_ROOT=/usr/share/verilator verilator_bin $(VERILATOR_TRACE) --cc --build --exe -Wno-WIDTH -Mdir `mktemp -d` -MAKEFLAGS CXX=g++ -CFLAGS -g --assert -CFLAGS " -fPIC" -o $@ $@.v $@.o $@.harness.cpp > /dev/null
+	@set -e ; \
+	VERILATOR_TMP_DIR=`mktemp -d` ; \
+	trap "rm -r $$VERILATOR_TMP_DIR" EXIT ; \
+	VERILATOR_ROOT=/usr/share/verilator ; \
+	verilator_bin $(VERILATOR_TRACE) --cc --build --exe -Wno-WIDTH -Mdir $$VERILATOR_TMP_DIR -MAKEFLAGS CXX=g++ -CFLAGS -g --assert -CFLAGS " -fPIC" -o $@ $@.v $@.o $@.harness.cpp > /dev/null
 
 # This target is used for running and checking built tests
 .PHONY: hls-test-run/%.hls


### PR DESCRIPTION
Each temporary directory created when compiling a `.c`-file with verilator ends up at about 180MB on my machine. These directories are placed in `/tmp`, which on my machine is a RAM-disk. I had to resize the tmpfs, as 8GB was not large enough. I also had to set up a swapfile to not run out of RAM.

This change makes it so the temporary directory for each test is deleted once verilator has produced its final executable `build/xxx/test_xxx.hls`. It is deleted even if the build fails or is interrupted.

Sidenote: This PR is from a fork, only because I did not have access to creating branches in this repository.